### PR TITLE
Fix per-game screen layout not persisting across sessions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -423,11 +423,11 @@ pub fn actual_main() {
 
     let mut running = true;
     while running {
-        let (mut cartridge_io, settings) = match presenter.present_ui(&mut screen_layouts) {
-            Some((cartridge_io, settings)) => (cartridge_io, settings),
+        let (mut cartridge_io, mut settings_config) = match presenter.present_ui(&mut screen_layouts) {
+            Some((cartridge_io, settings_config)) => (cartridge_io, settings_config),
             None => return,
         };
-        info_println!("{} Settings: {settings:?}", cartridge_io.file_name);
+        info_println!("{} Settings: {:?}", cartridge_io.file_name, settings_config.settings);
         presenter.on_game_launched();
 
         if gpu_renderer.is_none() {
@@ -461,7 +461,7 @@ pub fn actual_main() {
         info_println!("Found {} overlays", cartridge_io.overlays.len());
 
         emu_unsafe.get_mut().cartridge.set_cartridge_io(cartridge_io);
-        emu_unsafe.get_mut().settings = settings;
+        emu_unsafe.get_mut().settings = settings_config.settings.clone();
 
         sound_sampler.get_mut().init();
 
@@ -625,5 +625,11 @@ pub fn actual_main() {
         process_3d_thread.join().unwrap();
         save_thread.join().unwrap();
         gpu_renderer.set_quit(false);
+
+        // Persist per-game settings (including screen layout) to disk
+        emu_unsafe.get_mut().settings.set_screen_layout(&screen_layout);
+        settings_config.settings = emu_unsafe.get_mut().settings.clone();
+        settings_config.dirty = true;
+        settings_config.flush();
     }
 }

--- a/src/presenter/linux.rs
+++ b/src/presenter/linux.rs
@@ -9,7 +9,7 @@ use crate::presenter::imgui::root::{
 use crate::presenter::ui::{init_ui, show_main_menu, show_pause_menu, show_progress, CustomLayoutContext, UiBackend, UiPauseMenuReturn};
 use crate::presenter::{PresentEvent, PRESENTER_AUDIO_IN_BUF_SIZE, PRESENTER_AUDIO_OUT_BUF_SIZE, PRESENTER_AUDIO_OUT_SAMPLE_RATE, PRESENTER_SCREEN_HEIGHT, PRESENTER_SCREEN_WIDTH};
 use crate::screen_layouts::{CustomLayout, ScreenLayouts};
-use crate::settings::{Arm7Emu, Settings, DEFAULT_SETTINGS};
+use crate::settings::{Arm7Emu, Settings, SettingsConfig, DEFAULT_SETTINGS};
 use crate::utils::BuildNoHasher;
 use clap::{arg, command, value_parser, ArgAction, ArgMatches};
 use gl::types::GLuint;
@@ -158,7 +158,7 @@ impl Presenter {
         instance
     }
 
-    pub fn present_ui(&mut self, screen_layouts: &mut ScreenLayouts) -> Option<(CartridgeIo, Settings)> {
+    pub fn present_ui(&mut self, screen_layouts: &mut ScreenLayouts) -> Option<(CartridgeIo, SettingsConfig)> {
         let file_path = PathBuf::from(self.arg_matches.get_one::<String>("nds_rom").unwrap());
         if self.arg_matches.get_flag("ui") {
             if file_path.exists() && file_path.is_file() {
@@ -168,10 +168,10 @@ impl Presenter {
 
             match show_main_menu(file_path, screen_layouts, self) {
                 None => None,
-                Some((cartridge_io, global_settings, mut settings)) => {
+                Some((cartridge_io, global_settings, mut settings_config)) => {
                     screen_layouts.populate_custom_layouts(&global_settings.custom_layouts);
-                    settings.populate_screen_layouts(screen_layouts);
-                    Some((cartridge_io, settings))
+                    settings_config.settings.populate_screen_layouts(screen_layouts);
+                    Some((cartridge_io, settings_config))
                 }
             }
         } else {
@@ -185,7 +185,7 @@ impl Presenter {
             let preview = CartridgePreview::new(file_path).unwrap();
 
             settings.populate_screen_layouts(screen_layouts);
-            Some((CartridgeIo::from_preview(preview, save_path).unwrap(), settings))
+            Some((CartridgeIo::from_preview(preview, save_path).unwrap(), SettingsConfig::from(settings)))
         }
     }
 

--- a/src/presenter/ui.rs
+++ b/src/presenter/ui.rs
@@ -115,7 +115,7 @@ pub struct CustomLayoutContext {
     pub duplicated_name: bool,
 }
 
-pub fn show_main_menu(cartridge_path: PathBuf, screen_layouts: &mut ScreenLayouts, ui_backend: &mut impl UiBackend) -> Option<(CartridgeIo, GlobalSettings, Settings)> {
+pub fn show_main_menu(cartridge_path: PathBuf, screen_layouts: &mut ScreenLayouts, ui_backend: &mut impl UiBackend) -> Option<(CartridgeIo, GlobalSettings, SettingsConfig)> {
     unsafe {
         let saves_path = cartridge_path.join("saves");
         let global_settings_path = cartridge_path.join("global_settings");
@@ -479,7 +479,7 @@ pub fn show_main_menu(cartridge_path: PathBuf, screen_layouts: &mut ScreenLayout
         Some((
             CartridgeIo::from_preview(preview, save_file).unwrap(),
             global_settings,
-            settings_configs.remove(SELECTED.unwrap()).settings,
+            settings_configs.remove(SELECTED.unwrap()),
         ))
     }
 }

--- a/src/presenter/vita.rs
+++ b/src/presenter/vita.rs
@@ -286,7 +286,7 @@ impl Presenter {
         }
     }
 
-    pub fn present_ui(&mut self, screen_layouts: &mut ScreenLayouts) -> Option<(CartridgeIo, Settings)> {
+    pub fn present_ui(&mut self, screen_layouts: &mut ScreenLayouts) -> Option<(CartridgeIo, SettingsConfig)> {
         unsafe {
             sceShellUtilUnlock(SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN | SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN_2);
 
@@ -306,11 +306,11 @@ impl Presenter {
                                 let preview = CartridgePreview::new(path).unwrap();
 
                                 let global_settings = GlobalSettings::new(cartridge_path.join("global_settings")).unwrap();
-                                let mut settings = SettingsConfig::new(settings_file).settings;
+                                let mut settings_config = SettingsConfig::new(settings_file);
                                 screen_layouts.populate_custom_layouts(&global_settings.custom_layouts);
-                                settings.populate_screen_layouts(screen_layouts);
+                                settings_config.settings.populate_screen_layouts(screen_layouts);
 
-                                return Some((CartridgeIo::from_preview(preview, save_file).unwrap(), settings));
+                                return Some((CartridgeIo::from_preview(preview, save_file).unwrap(), settings_config));
                             }
                         }
                     }
@@ -319,10 +319,10 @@ impl Presenter {
 
             match show_main_menu(PathBuf::from(ROM_PATH), screen_layouts, self) {
                 None => None,
-                Some((cartridge_io, global_settings, mut settings)) => {
+                Some((cartridge_io, global_settings, mut settings_config)) => {
                     screen_layouts.populate_custom_layouts(&global_settings.custom_layouts);
-                    settings.populate_screen_layouts(screen_layouts);
-                    Some((cartridge_io, settings))
+                    settings_config.settings.populate_screen_layouts(screen_layouts);
+                    Some((cartridge_io, settings_config))
                 }
             }
         }

--- a/src/screen_layouts.rs
+++ b/src/screen_layouts.rs
@@ -218,8 +218,8 @@ const SCALE_FACTORS: [f32; 8] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
 pub struct ScreenLayout {
     pub index: usize,
     pub swap: bool,
-    top_scale_index: usize,
-    bottom_scale_index: usize,
+    pub top_scale_index: usize,
+    pub bottom_scale_index: usize,
     overlap: bool,
     screen_top: [f32; 16],
     screen_bottom: [f32; 16],

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -268,6 +268,8 @@ impl Settings {
     pub fn set_screen_layout(&mut self, screen_layout: &ScreenLayout) {
         *self.0[SettingIndices::ScreenLayout as usize].value.as_list_mut().unwrap().0 = screen_layout.index;
         *self.0[SettingIndices::SwapScreen as usize].value.as_bool_mut().unwrap() = screen_layout.swap;
+        *self.0[SettingIndices::TopScreenScale as usize].value.as_list_mut().unwrap().0 = screen_layout.top_scale_index;
+        *self.0[SettingIndices::BottomScreenScale as usize].value.as_list_mut().unwrap().0 = screen_layout.bottom_scale_index;
     }
 
     pub fn set_framelimit(&mut self, value: u8) {


### PR DESCRIPTION
## Summary
- Fixed `set_screen_layout()` to also save top/bottom screen scale indices back to `Settings`, not just layout index and swap flag
- Threaded `SettingsConfig` (which holds the INI file path) through the full game lifecycle instead of discarding it after the main menu
- Added automatic settings flush to disk when exiting a game, so all per-game settings including screen layout persist across sessions

Fixes #128

## Root Cause

Two bugs caused per-game screen layout settings to reset on restart:

1. **Incomplete `set_screen_layout()`** (`src/settings.rs`): Only saved `index` and `swap` fields, silently dropping `top_scale_index` and `bottom_scale_index` changes made during gameplay.

2. **Settings never written to disk** (`src/main.rs`, `src/presenter/`): The `SettingsConfig` struct (which contains both the `Settings` values and the file path for the `.ini` file) was consumed by `show_main_menu()` which only returned the inner `Settings` object. Without the file path, the game loop had no way to flush settings to disk on exit.

## Changes

| File | Change |
|------|--------|
| `src/settings.rs` | `set_screen_layout()` now also writes `TopScreenScale` and `BottomScreenScale` indices |
| `src/screen_layouts.rs` | Made `top_scale_index` and `bottom_scale_index` fields `pub` so `set_screen_layout()` can read them |
| `src/presenter/ui.rs` | `show_main_menu()` now returns full `SettingsConfig` instead of just `Settings` |
| `src/presenter/vita.rs` | `present_ui()` returns `SettingsConfig`; threads it through both launch paths |
| `src/presenter/linux.rs` | `present_ui()` returns `SettingsConfig`; wraps CLI-path settings in `SettingsConfig::from()` |
| `src/main.rs` | Receives `SettingsConfig` from `present_ui()`, calls `flush()` after game exit to persist settings |

## Test plan
- [ ] Set a per-game screen layout (e.g., "Focus") for a game, close the emulator, reopen it, and verify the layout is still "Focus"
- [ ] Change screen scale during gameplay (PS + Square / PS + Circle), quit, reopen, and verify scale persists
- [ ] Change swap screens during gameplay (PS + Cross), quit, reopen, and verify swap persists
- [ ] Modify settings in the pause menu, resume, quit, and verify changes persist
- [ ] Verify different games maintain independent screen layout settings
- [ ] Verify the "Save settings" button in the main menu still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)